### PR TITLE
Implement range filters

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -11,6 +11,7 @@ const operators = {
     '~': 'like',
     '<': 'less',
     '>': 'greater'
+    // 'between' will be handled differently
 };
 
 ql.setConfig({
@@ -22,6 +23,7 @@ ql.setConfig({
     string: '"',
     lookDelimiter: ' OR ',
     setDelimiter: ',',
+    rangeDelimiter: '..',
     roundBracket: ['(', ')'],
     squareBracket: ['[', ']'],
 
@@ -46,7 +48,17 @@ module.exports = function filterParser(input) {
 
     for (let i = 0; i < result.length; i++) {
         for (let j = 0; j < result[i].length; j++) {
-            result[i][j].operator = operators[result[i][j].operator];
+            if (result[i][j].range) {
+                if (result[i][j].operator === '=') {
+                    result[i][j].operator = 'between';
+                } else if (result[i][j].operator === '!=') {
+                    result[i][j].operator = 'notBetween';
+                } else throw new RequestError('invalid range operator');
+                result[i][j].value = result[i][j].range;
+                delete result[i][j].range;
+            } else {
+                result[i][j].operator = operators[result[i][j].operator];
+            }
         }
     }
 

--- a/test/filter.spec.js
+++ b/test/filter.spec.js
@@ -138,6 +138,18 @@ describe('filter parser', () => {
                 filterParser('a=1 asdfasdfsdfa');
             }).to.throw(Error);
         });
+
+        it('fails on invalid range', () => {
+            expect(() => {
+                filterParser('a=1..2..3');
+            }).to.throw(Error);
+        });
+
+        it('fails on invalid range operator', () => {
+            expect(() => {
+                filterParser('a>1..2');
+            }).to.throw(Error);
+        });
     });
 
     describe('attribute paths', () => {
@@ -204,6 +216,14 @@ describe('filter parser', () => {
         it('lessOrEqual', () => {
             expect(filterParser('equal<=1')[0][0].operator).to.equal('lessOrEqual');
         });
+
+        it('between', () => {
+            expect(filterParser('foo=10..20')[0][0].operator).to.equal('between');
+        });
+
+        it('notBetween', () => {
+            expect(filterParser('foo!=10..20')[0][0].operator).to.equal('notBetween');
+        });
     });
 
     describe('data types', () => {
@@ -239,6 +259,18 @@ describe('filter parser', () => {
             expect(() => {
                 filterParser('foo=NULL');
             }).to.throw(Error);
+        });
+    });
+
+    describe('ranges', () => {
+        it('parses ranges (int)', () => {
+            expect(filterParser('foo=10..20')).to.eql([[{ attribute: ['foo'], operator: 'between', value: [10, 20] }]]);
+        });
+
+        it('parses ranges (string)', () => {
+            expect(filterParser('foo="2018-01-01".."2019-01-01"')).to.eql([
+                [{ attribute: ['foo'], operator: 'between', value: ['2018-01-01', '2019-01-01'] }]
+            ]);
         });
     });
 


### PR DESCRIPTION
This makes use of https://github.com/godmodelabs/flora-ql/pull/1 

Operators are changed to "=" → "between" and "!=" → "notBetween" (other operators are not allowed). Also, the "range" property is moved to "value". This seems uncommon but is necessary to maintain the operators in flora-ql ("=" is not changed to "between") while allowing the use of "=" in range filter queries.

```js
parser.filter('date="2019-01-01".."2019-03-31"')
// [ [ { attribute: [ 'date' ], operator: 'between', value: [ '2019-01-01', '2019-03-31' ] } ] ]
```
