### PR TITLE
Added support for random order

### DIFF
--- a/lib/order.js
+++ b/lib/order.js
@@ -2,7 +2,7 @@
 
 const { RequestError } = require('flora-errors');
 
-const validOrders = ['asc', 'desc', 'topflop'];
+const validOrders = ['asc', 'desc', 'random', 'topflop'];
 
 /**
  * Parse "order" options.
@@ -20,14 +20,6 @@ module.exports = function orderParser(input) {
         throw new RequestError('order cannot be empty');
     }
 
-    // special case: ":random"
-    if (input === ':random') {
-        return {
-            attributePath: null,
-            direction: 'random'
-        };
-    }
-
     const output = [];
 
     Object.keys(components).forEach((i) => {
@@ -37,6 +29,9 @@ module.exports = function orderParser(input) {
         }
         if (s.length > 2) {
             throw new RequestError('Invalid order parameter: ' + components[i]);
+        }
+        if (s[0].length == 0) {
+            throw new RequestError('No attribute set to order');
         }
         if (validOrders.indexOf(s[1]) === -1) {
             throw new RequestError('Invalid order direction: ' + components[i]);

--- a/test/order.spec.js
+++ b/test/order.spec.js
@@ -69,7 +69,7 @@ describe('order-parser', () => {
         it('should be the only order element', () => {
             expect(() => {
                 orderParser(':random');
-            }).not.to.throw(Error);
+            }).to.throw(Error);
             expect(() => {
                 orderParser('name:asc,:random');
             }).to.throw(Error);
@@ -78,7 +78,7 @@ describe('order-parser', () => {
         it('should have no attribute', () => {
             expect(() => {
                 orderParser('name:random');
-            }).to.throw(Error);
+            }).not.to.throw(Error);
         });
     });
 


### PR DESCRIPTION
Added support for the `random` order attribute. Now requires an attribute name, because no global order property is available on resource level.