### PR TITLE
fix: use peggy instead of abandoned pegjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Request parser for Flora",
   "main": "index.js",
   "scripts": {
-    "install": "pegjs -o select-parser.js ./src/select-parser.pegjs",
+    "install": "peggy -o select-parser.js ./src/select-parser.pegjs",
     "test": "eslint . && mocha",
     "lint": "eslint ."
   },
@@ -28,7 +28,7 @@
   "dependencies": {
     "flora-errors": "^2.0.0",
     "flora-ql": "^3.2.3",
-    "pegjs": "^0.10.0"
+    "peggy": "^1.2.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Seems like PEG.js is abandoned, see https://github.com/pegjs/pegjs/issues/667 

This PR uses the (seemingly well maintained) drop-in replacement [peggy](https://github.com/peggyjs/peggy).